### PR TITLE
Change order of UI to make projectiles go under instead of over it

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -96,7 +96,6 @@ function draw() {
         }
         if (timeElapsed > 1000) {
           player.score++;
-          console.log(player.score);
           lastPrint = millis();
         }
 
@@ -232,7 +231,6 @@ function DebugDraw(){ //Draw function specifically for Debug menu (AKA Mode 2)
 function keyPressed(){
     pressedKeys[key] = true;
    if(keyCode === 32){  // if spacebar is pressed
-      console.log("Space firing");
       if(!player.isHit()){
         projectiles.push(new Projectile(player.x, player.y+1));
       }

--- a/src/main.js
+++ b/src/main.js
@@ -114,7 +114,7 @@ function draw() {
         button3.size(CANV_WIDTH*(55/720), CANV_HEIGHT/10); // sets size of button
         button3.mousePressed(OpenShield);
       }
-
+      gameUI();
       displayShieldInfo();
       
 
@@ -266,3 +266,11 @@ function checkProjectileHit() {
   }
 }
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+function gameUI() {
+  textSize(10*CANV_SCALAR);
+  text('Gametime: '+time+' sec',CANV_WIDTH/2,CANV_HEIGHT/20);// Show game time
+  textAlign(LEFT);
+  text('Score: ' + player.score, CANV_WIDTH/20, CANV_HEIGHT/20);// determines what is displayed, at what x,y
+  textAlign(CENTER);
+}

--- a/src/main.js
+++ b/src/main.js
@@ -21,7 +21,6 @@ let pressedKeys = {}; // Holding for the pressed keys
 let enemies = []; // array to hold enemy objects
 let projectiles = []; // array to hold projectile objects
 let fpsCounter;
-let prop = false;// Energy shield presence state
 let energiesarray = [];// Array of shield energy cycles
 let energies = 0;// Number of energy blocks
 let enemyOn = new Boolean(true); // For use in debug. Defaults to true in normal mode. Will turn on or off enemy spawning.
@@ -109,7 +108,7 @@ function draw() {
       enemy1.showcase(enemySpawnDelay); //update, draw, and spawn enemies
 
       projectile1.showcase();
-      if (energies == 1 && prop == false){// Start shield button is displayed when the number of energy blocks is greater than 1
+      if (energies == 1 && player.shield == false){// Start shield button is displayed when the number of energy blocks is greater than 1
         button3 = createButton('Shield');
         button3.position(CANV_WIDTH*(65/72), CANV_HEIGHT*(21/40)); // set button position
         button3.size(CANV_WIDTH*(55/720), CANV_HEIGHT/10); // sets size of button
@@ -128,7 +127,7 @@ function draw() {
           for (let enmy of enemies){ // checks each enemy for collision
             if (intersect(player.x, player.y, player.size-5, enmy.posX, enmy.posY, enmy.size)){
               player.setHitTrue();
-              if(energies > 0 && prop == false){// Death removes shield button if present
+              if(energies > 0 && player.shield == false){// Death removes shield button if present
                 removeElements(button3);
               }
               mode = 9;

--- a/src/main.js
+++ b/src/main.js
@@ -115,6 +115,8 @@ function draw() {
         button3.size(CANV_WIDTH*(55/720), CANV_HEIGHT/10); // sets size of button
         button3.mousePressed(OpenShield);
       }
+
+      displayShieldInfo();
       
 
         if(mode == 5){// Invincible Mode

--- a/src/player-related.js
+++ b/src/player-related.js
@@ -54,6 +54,15 @@ class Player {
   
     display() { //Draws the player
 
+      //Draws Shield
+      if(player.shield == true){
+        stroke(58, 214, 134);
+        fill(255, 255, 255);
+        rect(this.x, this.y, this.size*3, this.size*6, 20); 
+        textSize(10*CANV_SCALAR);
+        text('Shield time: '+(ShieldCT+1)+' sec',CANV_WIDTH*(60/72),CANV_HEIGHT/20); // Shield time
+      }
+
       //Draws wake behind boat
         stroke(255,255,250); //Outline color
         fill(220, 250, 253); //Color of shape
@@ -72,21 +81,12 @@ class Player {
         rectMode(CENTER);
         square(this.x, this.y+this.size/4, this.size/3);
 
-        textSize(10*CANV_SCALAR);
+      //  textSize(10*CANV_SCALAR);
 
-        text('Gametime: '+time+' sec',CANV_WIDTH/2,CANV_HEIGHT/20);// Show game time
-        textAlign(LEFT);
-        text('Score: ' + this.score, CANV_WIDTH/20, CANV_HEIGHT/20);// determines what is displayed, at what x,y
-        textAlign(CENTER);
-
-        //Draws Shield
-        if(player.shield == true){
-          stroke(58, 214, 134);
-          fill(255, 255, 255);
-          rect(this.x, this.y, this.size*3, this.size*6, 20); 
-          textSize(10*CANV_SCALAR);
-          text('Shield time: '+(ShieldCT+1)+' sec',CANV_WIDTH*(60/72),CANV_HEIGHT/20); // Shield time
-        }
+      //  text('Gametime: '+time+' sec',CANV_WIDTH/2,CANV_HEIGHT/20);// Show game time
+      //  textAlign(LEFT);
+      //  text('Score: ' + this.score, CANV_WIDTH/20, CANV_HEIGHT/20);// determines what is displayed, at what x,y
+      //  textAlign(CENTER);
     }
 
 

--- a/src/player-related.js
+++ b/src/player-related.js
@@ -11,6 +11,7 @@ class Player {
         this.score = 0; // Used to keep track of player score
         this.task_done = false;
         this.last_done = 0;
+        this.shield = false
         //creates private hit flag
         let hit = false;
         this.isHit = function() { return hit; };
@@ -77,6 +78,17 @@ class Player {
         textAlign(LEFT);
         text('Score: ' + this.score, CANV_WIDTH/20, CANV_HEIGHT/20);// determines what is displayed, at what x,y
         textAlign(CENTER);
+
+        //Draws Shield
+        if(player.shield == true){
+          stroke(58, 214, 134);
+          fill(255, 255, 255);
+          rect(this.x, this.y, this.size*3, this.size*6, 20); 
+          textSize(10*CANV_SCALAR);
+          text('Shield time: '+(ShieldCT+1)+' sec',CANV_WIDTH*(60/72),CANV_HEIGHT/20); // Shield time
+        }
     }
+
+
 
 }

--- a/src/player-related.js
+++ b/src/player-related.js
@@ -52,27 +52,6 @@ class Player {
     }
   
     display() { //Draws the player
-      
-      //Draws energy tanks
-        stroke(58, 127, 214);
-        fill(205, 205, 205);
-        rect(CANV_WIDTH*(677/720), CANV_HEIGHT*(116/400), CANV_WIDTH*(30/720), CANV_HEIGHT*(176/400), 5);
-      
-      // Draws Energy Blocks
-        for(var i = 0; i < 10; i++){
-          stroke(0,0,0);
-          fill(255, 156, 51);
-          rect(CANV_WIDTH*(677/720), energiesarray[i], CANV_WIDTH*(30/720), CANV_HEIGHT*(15/400), 20);
-        }
-      
-      //Draws Shield
-      if(prop == true){
-        stroke(58, 214, 134);
-        fill(255, 255, 255);
-        rect(this.x, this.y, this.size*3, this.size*6, 20); 
-        textSize(10*CANV_SCALAR);
-        text('Shield time: '+(ShieldCT+1)+' sec',CANV_WIDTH*(60/72),CANV_HEIGHT/20); // Shield time
-        }
 
       //Draws wake behind boat
         stroke(255,255,250); //Outline color

--- a/src/projectile-related.js
+++ b/src/projectile-related.js
@@ -35,7 +35,6 @@ class Projectile {
       if (this.posY > CANV_HEIGHT || this.posX > CANV_WIDTH || this.posX < 0 || this.hit == true) {
       let index = projectiles.indexOf(this);
       projectiles.splice(index, 1);
-      console.log('projectile deleted');
       }
    }
 

--- a/src/shield-related.js
+++ b/src/shield-related.js
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 function energie(){// Generate an energy block every 5 seconds
-  if(energies<10 && prop == false){
+  if(energies<10 && player.shield == false){
     energiesarray[energies] = 40+energies*17;
     energies++;
     ShieldCT = ShieldCT + 5;
@@ -12,7 +12,8 @@ function energie(){// Generate an energy block every 5 seconds
 }
 
 function Shieldtime(){// Turns off invincibility mode at the end of the energy shield's duration and changes the shield's state
-  player.display(prop = false);
+  player.shield = false
+  player.display();
   mode = 1;
   setTimeout(energie, 5000);
 }
@@ -26,7 +27,8 @@ function ShieldCountdown(){ //Shield Countdown
 
 function OpenShield(){ //  Open Shield
   removeElements(button3); // Disable Shield Button
-  player.display(prop = true);// Change shield status and display shield
+  player.shield = true
+  player.display();// Change shield status and display shield
   mode = 5; //Toggle Invincible Mode
   ShieldCountdown();// Shield Countdown
   setTimeout(Shieldtime, 5000*(energies));// Shield Duration
@@ -47,12 +49,4 @@ function displayShieldInfo() {
      rect(CANV_WIDTH*(677/720), energiesarray[i], CANV_WIDTH*(30/720), CANV_HEIGHT*(15/400), 20);
    }
  
- //Draws Shield
- if(prop == true){
-   stroke(58, 214, 134);
-   fill(255, 255, 255);
-   rect(this.x, this.y, this.size*3, this.size*6, 20); 
-   textSize(10*CANV_SCALAR);
-   text('Shield time: '+(ShieldCT+1)+' sec',CANV_WIDTH*(60/72),CANV_HEIGHT/20); // Shield time
- }
 }

--- a/src/shield-related.js
+++ b/src/shield-related.js
@@ -33,3 +33,26 @@ function OpenShield(){ //  Open Shield
   energies = 0;// Empty energy
   energiesarray = [];// Empty energy
 }
+
+function displayShieldInfo() {
+   //Draws energy tanks
+   stroke(58, 127, 214);
+   fill(205, 205, 205);
+   rect(CANV_WIDTH*(677/720), CANV_HEIGHT*(116/400), CANV_WIDTH*(30/720), CANV_HEIGHT*(176/400), 5);
+ 
+ // Draws Energy Blocks
+   for(var i = 0; i < 10; i++){
+     stroke(0,0,0);
+     fill(255, 156, 51);
+     rect(CANV_WIDTH*(677/720), energiesarray[i], CANV_WIDTH*(30/720), CANV_HEIGHT*(15/400), 20);
+   }
+ 
+ //Draws Shield
+ if(prop == true){
+   stroke(58, 214, 134);
+   fill(255, 255, 255);
+   rect(this.x, this.y, this.size*3, this.size*6, 20); 
+   textSize(10*CANV_SCALAR);
+   text('Shield time: '+(ShieldCT+1)+' sec',CANV_WIDTH*(60/72),CANV_HEIGHT/20); // Shield time
+ }
+}

--- a/src/shield-related.js
+++ b/src/shield-related.js
@@ -4,7 +4,7 @@
 
 function energie(){// Generate an energy block every 5 seconds
   if(energies<10 && player.shield == false){
-    energiesarray[energies] = 40+energies*17;
+    energiesarray[energies] = 75+energies*32;
     energies++;
     ShieldCT = ShieldCT + 5;
     setTimeout(energie, 5000);


### PR DESCRIPTION
Projectiles now travel under the UI instead of on top of it. 

I also changed how the player shield is activated--instead of global 'prop' it is now player.shield